### PR TITLE
Update the license to be recognized by GH

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+BSD 2-Clause License
+
 Copyright (c) 2012-2016, David Trail
 All rights reserved.
 
@@ -20,7 +22,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
-either expressed or implied, of the Shreddit Project.


### PR DESCRIPTION
This is NOT a change in license. The original repository was licensed under BSD 2-Clause. This maintains that.

This solely updates the format of the license to match https://choosealicense.com/licenses/bsd-2-clause/ so that it can be properly recognized by GH.