### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3.1.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2.5.1
+        uses: actions/dependency-review-action@v3.0.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/dependency-review-action](https://github.com/actions/dependency-review-action)** published a new release **[v3.0.0](https://github.com/actions/dependency-review-action/releases/tag/v3.0.0)** on 2022-11-11T15:19:28Z
