### PR TITLE
ci: change release workflow to manual trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Change release workflow from automatic trigger to manual dispatch
- Releases must now be manually triggered via GitHub Actions UI when ready

## Changes

- Replace `on: push: branches: [main]` with `on: workflow_dispatch` in release workflow

## How It Works

1. Go to Actions tab → Release workflow
2. Click "Run workflow" button when ready to create a release
3. Semantic-release analyzes commits and creates release if there are releasable changes
4. All existing functionality (versioning, changelog, binaries, Docker) works the same

## Benefits

- Full control over release timing
- Can batch multiple PRs before releasing
- No accidental releases from merging to main
- Simple one-line change, easy to revert if needed