### PR TITLE
fix: add issues write permission to Docker Security Scan workflow

### DIFF
--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   packages: write
   security-events: write
   id-token: write


### PR DESCRIPTION
## Problem
The Docker Security Scan workflow was failing with a 403 error when trying to create/update GitHub issues for detected vulnerabilities.

Error: `Resource not accessible by integration`

## Solution
Added `issues: write` permission to the workflow permissions block. This allows the workflow to create and update issues to notify about security vulnerabilities.

## Change
```diff
permissions:
  contents: read
+ issues: write
  packages: write
  security-events: write
  id-token: write
```

## Testing
After this PR merges, the workflow should be able to successfully create/update issues when vulnerabilities are detected.