### PR TITLE
fix: replace pkg_resources with importlib.resources for Python 3.14 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shreddit"
-version = "6.4.1"
+version = "6.4.2"
 description = "Remove your comment history on Reddit as deleting an account does not do so."
 readme = "README.md"
 license = { text = "FreeBSD License" }
@@ -25,7 +25,6 @@ dependencies = [
     "praw>=7.5.0",
     "PyYAML>=6.0.1",
     "requests>=2.32.4",
-    "setuptools>=65.0.0",
     "six>=1.12",
     "tornado>=6.5.1",
     "prometheus-client>=0.16.0",

--- a/shreddit/app.py
+++ b/shreddit/app.py
@@ -2,8 +2,8 @@
 """
 import argparse
 import os
+from importlib import resources
 
-import pkg_resources
 import yaml
 from appdirs import user_config_dir
 
@@ -24,11 +24,11 @@ def main():
         if not os.path.isfile("shreddit.yml"):
             print("Writing shreddit.yml file...")
             with open("shreddit.yml", "wb") as fout:
-                fout.write(pkg_resources.resource_string("shreddit", "shreddit.yml.example"))
+                fout.write(resources.files("shreddit").joinpath("shreddit.yml.example").read_bytes())
         if not os.path.isfile("praw.ini"):
             print("Writing praw.ini file...")
             with open("praw.ini", "wb") as fout:
-                fout.write(pkg_resources.resource_string("shreddit", "praw.ini.example"))
+                fout.write(resources.files("shreddit").joinpath("praw.ini.example").read_bytes())
         return
 
     config_dir = user_config_dir("shreddit/shreddit.yml")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,35 @@
+"""Tests for the app entrypoint module."""
+import os
+import tempfile
+from unittest.mock import patch
+
+from shreddit.app import main
+
+
+class TestImportSmoke:
+    """Smoke tests to ensure the app module imports cleanly."""
+
+    def test_import_main(self):
+        """Test that the app module and main function can be imported.
+
+        This catches issues like missing dependencies that only trigger
+        when the module is loaded (e.g. pkg_resources on Python 3.14+).
+        """
+        assert callable(main)
+
+
+class TestGenerateConfigs:
+    """Tests for the -g/--generate-configs flag."""
+
+    def test_generate_configs_creates_files(self):
+        """Test that -g creates shreddit.yml and praw.ini in the current directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_dir = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                with patch("sys.argv", ["shreddit", "-g"]):
+                    main()
+                assert os.path.isfile(os.path.join(tmpdir, "shreddit.yml"))
+                assert os.path.isfile(os.path.join(tmpdir, "praw.ini"))
+            finally:
+                os.chdir(original_dir)


### PR DESCRIPTION
## Summary
- Replace `pkg_resources` with `importlib.resources` in `shreddit/app.py`, fixing `ModuleNotFoundError: No module named 'pkg_resources'` on Python 3.14
- Remove `setuptools` from dependencies since it's no longer needed
- Bump version to 6.4.2

## Context
The Docker image (`python:3.14-alpine`) doesn't include `setuptools` by default, and `pkg_resources` was removed from the stdlib in Python 3.14. This caused shreddit to crash on every invocation.

## Test plan
- [ ] Verify `docker build .` succeeds
- [ ] Verify `shreddit -g` generates config files correctly
- [ ] Verify normal shreddit invocation works against Reddit API